### PR TITLE
Fix issue1

### DIFF
--- a/debian/libfsmtrie1.symbols
+++ b/debian/libfsmtrie1.symbols
@@ -2,6 +2,7 @@ libfsmtrie.so.1 libfsmtrie1 #MINVER#
  _mode_to_str@Base 1.0.0-1
  fsmtrie_error@Base 1.0.0-1
  fsmtrie_free@Base 1.0.0-1
+ fsmtrie_destroy@Base 1.0.0-1
  fsmtrie_get_error@Base 1.0.0-1
  fsmtrie_get_keycnt@Base 1.0.0-1
  fsmtrie_get_nodecnt@Base 1.0.0-1

--- a/examples/ascii.c
+++ b/examples/ascii.c
@@ -116,7 +116,7 @@ int main(int argc, char **argv)
 			fprintf(stderr, "failed to insert key \"%s\": %s\n",
 					keys[n],
 					fsmtrie_error(fsmtrie));
-			fsmtrie_free(fsmtrie);
+			fsmtrie_destroy(&fsmtrie);
 			fsmtrie_opt_free(opt);
 			return (EXIT_FAILURE);
 		}
@@ -205,7 +205,7 @@ int main(int argc, char **argv)
 		}
 	}
 
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
 	fsmtrie_opt_free(opt);
 
 	return (EXIT_SUCCESS);

--- a/examples/eascii.c
+++ b/examples/eascii.c
@@ -91,6 +91,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
+		fsmtrie_opt_free(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -102,7 +103,8 @@ int main(int argc, char **argv)
 			fprintf(stderr, "failed to insert key \"%s\": %s\n",
 					keys[n],
 					fsmtrie_error(fsmtrie));
-			fsmtrie_free(fsmtrie);
+			fsmtrie_destroy(&fsmtrie);
+			fsmtrie_opt_free(opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -212,7 +214,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
+	fsmtrie_opt_free(opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/examples/token.c
+++ b/examples/token.c
@@ -74,6 +74,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
+		fsmtrie_opt_free(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -85,7 +86,8 @@ int main(int argc, char **argv)
 			fprintf(stderr, "failed to insert key \"%s\": %s\n",
 					key_names[n],
 					fsmtrie_error(fsmtrie));
-			fsmtrie_free(fsmtrie);
+			fsmtrie_destroy(&fsmtrie);
+			fsmtrie_opt_free(opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -139,7 +141,8 @@ int main(int argc, char **argv)
 		}
 	}
 
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
+	fsmtrie_opt_free(opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/fsmtrie/fsmtrie.c
+++ b/fsmtrie/fsmtrie.c
@@ -766,6 +766,15 @@ fsmtrie_free(struct fsmtrie *f)
 	f->node_cnt = 0;
 }
 
+void
+fsmtrie_destroy(struct fsmtrie **f)
+{
+	fsmtrie_free(*f);
+
+	free(*f);
+	*f = NULL;
+}
+
 int
 fsmtrie_search_ascii(struct fsmtrie *f, const char *key, const char **str)
 {

--- a/fsmtrie/fsmtrie.h
+++ b/fsmtrie/fsmtrie.h
@@ -293,9 +293,23 @@ bool fsmtrie_insert_token(fsmtrie_t fsmtrie, uint32_t *tkey, size_t nkey,
 /**
  *  Decommission a specified fsmtrie and free all memory associated with it.
  *
- *  \param[in] fsmtrie valid fsmtrie object
+ *  Note that this function does not free the memory associated with fsmtrie,
+ *  and free() should be called to avoid leaking that memory.
+ *
+ *  This function is deprecated in favor of fsmtrie_destroy().
+ *
+ *  \param[in] fsmtrie a valid fsmtrie object
  */
 void fsmtrie_free(fsmtrie_t fsmtrie);
+
+
+/**
+ *  Destroy a specified fsmtrie, freeing all memory associated with it.
+ *
+ *  \param[in] fsmtrie pointer to a valid fsmtrie object
+ */
+void fsmtrie_destroy(fsmtrie_t *fsmtrie);
+
 
 /**
  *  Search a specified fsmtrie for a key. If key is found, str may point to

--- a/tests/test-trie-insert-and-asearch-subsearch.c
+++ b/tests/test-trie-insert-and-asearch-subsearch.c
@@ -102,7 +102,7 @@ START_TEST(test_trie_insert_and_asearch_subsearch)
 		subsearch_report_trial2, "farsightsecurity"), 1);
 
 	fsmtrie_opt_free(opt);
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
 

--- a/tests/test-trie-insert-and-search.c
+++ b/tests/test-trie-insert-and-search.c
@@ -61,7 +61,7 @@ START_TEST(test_trie_insert_and_search)
 	ck_assert_ptr_eq(str, NULL);
 
 	fsmtrie_opt_free(opt);
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
 
@@ -137,7 +137,7 @@ START_TEST(test_trie_insert_and_search_token)
 	}
 
 	fsmtrie_opt_free(opt);
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
 
@@ -176,7 +176,7 @@ START_TEST(test_trie_insert_and_search_ml)
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "xxxxxxxxxx", &str), 0);
 
 	fsmtrie_opt_free(opt);
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
 
@@ -226,7 +226,7 @@ START_TEST(test_trie_insert_and_search_utf8)
 	ck_assert_ptr_eq(str, NULL);
 
 	fsmtrie_opt_free(opt);
-	fsmtrie_free(fsmtrie);
+	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
 


### PR DESCRIPTION
This adds a new API function, `fsmtrie_destroy()` that fully frees memory associated with an `fsmtrie_t` object.