### PR TITLE
Fix issue2

### DIFF
--- a/debian/libfsmtrie1.symbols
+++ b/debian/libfsmtrie1.symbols
@@ -15,6 +15,7 @@ libfsmtrie.so.1 libfsmtrie1 #MINVER#
  fsmtrie_insert_token@Base 1.0.0-1
  fsmtrie_key_validate_ascii@Base 1.0.0-1
  fsmtrie_opt_free@Base 1.0.0-1
+ fsmtrie_opt_destroy@Base 1.0.0-1
  fsmtrie_opt_get_maxlength@Base 1.0.0-1
  fsmtrie_opt_get_mode@Base 1.0.0-1
  fsmtrie_opt_get_partialmatch@Base 1.0.0-1

--- a/examples/ascii.c
+++ b/examples/ascii.c
@@ -83,19 +83,19 @@ int main(int argc, char **argv)
 	if (!fsmtrie_opt_set_mode(opt, fsmtrie_mode_ascii))
 	{
 		fprintf(stderr, "can't set mode\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_maxlength(opt, 64))
 	{
 		fprintf(stderr, "can't set max length\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_partialmatch(opt, true))
 	{
 		fprintf(stderr, "can't set partial match flag\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 					keys[n],
 					fsmtrie_error(fsmtrie));
 			fsmtrie_destroy(&fsmtrie);
-			fsmtrie_opt_destroy(opt);
+			fsmtrie_opt_destroy(&opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 	}
 
 	fsmtrie_destroy(&fsmtrie);
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/examples/ascii.c
+++ b/examples/ascii.c
@@ -83,19 +83,19 @@ int main(int argc, char **argv)
 	if (!fsmtrie_opt_set_mode(opt, fsmtrie_mode_ascii))
 	{
 		fprintf(stderr, "can't set mode\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_maxlength(opt, 64))
 	{
 		fprintf(stderr, "can't set max length\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_partialmatch(opt, true))
 	{
 		fprintf(stderr, "can't set partial match flag\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -117,7 +117,7 @@ int main(int argc, char **argv)
 					keys[n],
 					fsmtrie_error(fsmtrie));
 			fsmtrie_destroy(&fsmtrie);
-			fsmtrie_opt_free(opt);
+			fsmtrie_opt_destroy(opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -206,7 +206,7 @@ int main(int argc, char **argv)
 	}
 
 	fsmtrie_destroy(&fsmtrie);
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/examples/eascii.c
+++ b/examples/eascii.c
@@ -70,19 +70,19 @@ int main(int argc, char **argv)
 	if (!fsmtrie_opt_set_mode(opt, fsmtrie_mode_eascii))
 	{
 		fprintf(stderr, "can't set mode\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_maxlength(opt, 64))
 	{
 		fprintf(stderr, "can't set max length\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_partialmatch(opt, true))
 	{
 		fprintf(stderr, "can't set partial match flag\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 					keys[n],
 					fsmtrie_error(fsmtrie));
 			fsmtrie_destroy(&fsmtrie);
-			fsmtrie_opt_destroy(opt);
+			fsmtrie_opt_destroy(&opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
 	}
 
 	fsmtrie_destroy(&fsmtrie);
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/examples/eascii.c
+++ b/examples/eascii.c
@@ -70,19 +70,19 @@ int main(int argc, char **argv)
 	if (!fsmtrie_opt_set_mode(opt, fsmtrie_mode_eascii))
 	{
 		fprintf(stderr, "can't set mode\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_maxlength(opt, 64))
 	{
 		fprintf(stderr, "can't set max length\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 	if (!fsmtrie_opt_set_partialmatch(opt, true))
 	{
 		fprintf(stderr, "can't set partial match flag\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -91,7 +91,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -104,7 +104,7 @@ int main(int argc, char **argv)
 					keys[n],
 					fsmtrie_error(fsmtrie));
 			fsmtrie_destroy(&fsmtrie);
-			fsmtrie_opt_free(opt);
+			fsmtrie_opt_destroy(opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -215,7 +215,7 @@ int main(int argc, char **argv)
 	}
 
 	fsmtrie_destroy(&fsmtrie);
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/examples/token.c
+++ b/examples/token.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 	if (!fsmtrie_opt_set_mode(opt, fsmtrie_mode_token))
 	{
 		fprintf(stderr, "can't set mode\n");
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
-		fsmtrie_opt_destroy(opt);
+		fsmtrie_opt_destroy(&opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 					key_names[n],
 					fsmtrie_error(fsmtrie));
 			fsmtrie_destroy(&fsmtrie);
-			fsmtrie_opt_destroy(opt);
+			fsmtrie_opt_destroy(&opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	}
 
 	fsmtrie_destroy(&fsmtrie);
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/examples/token.c
+++ b/examples/token.c
@@ -65,7 +65,7 @@ int main(int argc, char **argv)
 	if (!fsmtrie_opt_set_mode(opt, fsmtrie_mode_token))
 	{
 		fprintf(stderr, "can't set mode\n");
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -74,7 +74,7 @@ int main(int argc, char **argv)
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);
-		fsmtrie_opt_free(opt);
+		fsmtrie_opt_destroy(opt);
 		return (EXIT_FAILURE);
 	}
 
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 					key_names[n],
 					fsmtrie_error(fsmtrie));
 			fsmtrie_destroy(&fsmtrie);
-			fsmtrie_opt_free(opt);
+			fsmtrie_opt_destroy(opt);
 			return (EXIT_FAILURE);
 		}
 	}
@@ -142,7 +142,7 @@ int main(int argc, char **argv)
 	}
 
 	fsmtrie_destroy(&fsmtrie);
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 
 	return (EXIT_SUCCESS);
 }

--- a/fsmtrie/fsmtrie.c
+++ b/fsmtrie/fsmtrie.c
@@ -164,6 +164,12 @@ fsmtrie_opt_free(struct fsmtrie_opt *o)
 	}
 }
 
+void
+fsmtrie_opt_destroy(struct fsmtrie_opt *o)
+{
+	fsmtrie_opt_free(o);
+}
+
 bool
 fsmtrie_opt_set_mode(struct fsmtrie_opt *o, fsmtrie_mode mode)
 {

--- a/fsmtrie/fsmtrie.c
+++ b/fsmtrie/fsmtrie.c
@@ -165,9 +165,11 @@ fsmtrie_opt_free(struct fsmtrie_opt *o)
 }
 
 void
-fsmtrie_opt_destroy(struct fsmtrie_opt *o)
+fsmtrie_opt_destroy(struct fsmtrie_opt **o)
 {
-	fsmtrie_opt_free(o);
+	fsmtrie_opt_free(*o);
+
+	*o = NULL;
 }
 
 bool

--- a/fsmtrie/fsmtrie.h
+++ b/fsmtrie/fsmtrie.h
@@ -300,17 +300,19 @@ bool fsmtrie_insert_eascii(fsmtrie_t fsmtrie, const char *key,
 bool fsmtrie_insert_token(fsmtrie_t fsmtrie, uint32_t *tkey, size_t nkey,
 		const char *str);
 
-/**
- *  Decommission a specified fsmtrie and free all memory associated with it.
+/* @cond */
+/*
+ *  Decommission a specified fsmtrie, freeing only the held memory internal
+ *  to the object.
  *
- *  Note that this function does not free the memory associated with fsmtrie,
- *  and free() should be called to avoid leaking that memory.
+ *  Note that this function does not free the memory associated with the
+ *  fsmtrie object wrapper itself and free() should be called to avoid leaking
+ *  that memory.
  *
  *  This function is deprecated in favor of fsmtrie_destroy().
- *
- *  \param[in] fsmtrie a valid fsmtrie object
  */
 void fsmtrie_free(fsmtrie_t fsmtrie);
+/* @endcond */
 
 
 /**

--- a/fsmtrie/fsmtrie.h
+++ b/fsmtrie/fsmtrie.h
@@ -148,13 +148,23 @@ fsmtrie_t fsmtrie_init(fsmtrie_opt_t opt, char *err_buf);
  */
 fsmtrie_opt_t fsmtrie_opt_init(void);
 
+/* @cond */
+/*
+ *  Decommission a specified fsmtrie options object and free all memory
+ *  associated with it.
+ *
+ *  This function is deprecated in favor of fsmtrie_opt_destroy().
+ */
+void fsmtrie_opt_free(fsmtrie_opt_t opt);
+/* @endcond */
+
 /**
  *  Decommission a specified fsmtrie options object and free all memory
  *  associated with it.
  *
  *  \param[in] opt valid fsmtrie options object
  */
-void fsmtrie_opt_free(fsmtrie_opt_t opt);
+void fsmtrie_opt_destroy(fsmtrie_opt_t opt);
 
 /**
  *  Set the fsmtrie mode.

--- a/fsmtrie/fsmtrie.h
+++ b/fsmtrie/fsmtrie.h
@@ -162,9 +162,9 @@ void fsmtrie_opt_free(fsmtrie_opt_t opt);
  *  Decommission a specified fsmtrie options object and free all memory
  *  associated with it.
  *
- *  \param[in] opt valid fsmtrie options object
+ *  \param[in] opt pointer to a valid fsmtrie options object
  */
-void fsmtrie_opt_destroy(fsmtrie_opt_t opt);
+void fsmtrie_opt_destroy(fsmtrie_opt_t *opt);
 
 /**
  *  Set the fsmtrie mode.

--- a/tests/test-trie-insert-and-asearch-subsearch.c
+++ b/tests/test-trie-insert-and-asearch-subsearch.c
@@ -101,7 +101,7 @@ START_TEST(test_trie_insert_and_asearch_subsearch)
 	ck_assert_int_eq(fsmtrie_search_substring(fsmtrie, "farsightsecurity",
 		subsearch_report_trial2, "farsightsecurity"), 1);
 
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST

--- a/tests/test-trie-insert-and-asearch-subsearch.c
+++ b/tests/test-trie-insert-and-asearch-subsearch.c
@@ -101,7 +101,7 @@ START_TEST(test_trie_insert_and_asearch_subsearch)
 	ck_assert_int_eq(fsmtrie_search_substring(fsmtrie, "farsightsecurity",
 		subsearch_report_trial2, "farsightsecurity"), 1);
 
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST

--- a/tests/test-trie-insert-and-search.c
+++ b/tests/test-trie-insert-and-search.c
@@ -60,7 +60,7 @@ START_TEST(test_trie_insert_and_search)
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "farsightsecurit", &str), 1);
 	ck_assert_ptr_eq(str, NULL);
 
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
@@ -136,7 +136,7 @@ START_TEST(test_trie_insert_and_search_token)
 					&str), 0);
 	}
 
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
@@ -175,7 +175,7 @@ START_TEST(test_trie_insert_and_search_ml)
 	/* test partial match mode: should fail */
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "xxxxxxxxxx", &str), 0);
 
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
@@ -225,7 +225,7 @@ START_TEST(test_trie_insert_and_search_utf8)
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "ѡіΝᛕ", &str), 1);
 	ck_assert_ptr_eq(str, NULL);
 
-	fsmtrie_opt_free(opt);
+	fsmtrie_opt_destroy(opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST

--- a/tests/test-trie-insert-and-search.c
+++ b/tests/test-trie-insert-and-search.c
@@ -60,7 +60,7 @@ START_TEST(test_trie_insert_and_search)
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "farsightsecurit", &str), 1);
 	ck_assert_ptr_eq(str, NULL);
 
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
@@ -136,7 +136,7 @@ START_TEST(test_trie_insert_and_search_token)
 					&str), 0);
 	}
 
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
@@ -175,7 +175,7 @@ START_TEST(test_trie_insert_and_search_ml)
 	/* test partial match mode: should fail */
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "xxxxxxxxxx", &str), 0);
 
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST
@@ -225,7 +225,7 @@ START_TEST(test_trie_insert_and_search_utf8)
 	ck_assert_int_eq(fsmtrie_search(fsmtrie, "ѡіΝᛕ", &str), 1);
 	ck_assert_ptr_eq(str, NULL);
 
-	fsmtrie_opt_destroy(opt);
+	fsmtrie_opt_destroy(&opt);
 	fsmtrie_destroy(&fsmtrie);
 }
 END_TEST


### PR DESCRIPTION
- Adds `fsmtrie_opt_destroy()`
- Deprecates `fsmtrie_opt_free()` and removes it from the public API
- Removes `fsmtrie_free()` from the public API