### PR TITLE
fsmtrie_init() should not assume the size of its error buffer argument

### DIFF
--- a/examples/ascii.c
+++ b/examples/ascii.c
@@ -100,7 +100,7 @@ int main(int argc, char **argv)
 	}
 
 	printf("Initializing new ASCII fsmtrie\n");
-	fsmtrie = fsmtrie_init(opt, err_buf);
+	fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf));
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);

--- a/examples/eascii.c
+++ b/examples/eascii.c
@@ -87,7 +87,7 @@ int main(int argc, char **argv)
 	}
 
 	printf("Initializing new EASCII fsmtrie\n");
-	fsmtrie = fsmtrie_init(opt, err_buf);
+	fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf));
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);

--- a/examples/token.c
+++ b/examples/token.c
@@ -70,7 +70,7 @@ int main(int argc, char **argv)
 	}
 
 	printf("Initializing new token fsmtrie\n");
-	fsmtrie = fsmtrie_init(opt, err_buf);
+	fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf));
 	if (fsmtrie == NULL)
 	{
 		fprintf(stderr, "%s\n", err_buf);

--- a/fsmtrie/fsmtrie.c
+++ b/fsmtrie/fsmtrie.c
@@ -69,7 +69,7 @@ fsmtrie_get_error(struct fsmtrie *f)
 }
 
 struct fsmtrie *
-fsmtrie_init(struct fsmtrie_opt *o, char *err_buf)
+fsmtrie_init(struct fsmtrie_opt *o, char *err_buf, size_t err_buf_len)
 {
 	struct fsmtrie *f;
 	fsmtrie_mode mode;
@@ -79,7 +79,7 @@ fsmtrie_init(struct fsmtrie_opt *o, char *err_buf)
 	f = calloc(1, sizeof (struct fsmtrie));
 	if (f == NULL)
 	{
-		snprintf(err_buf, BUFSIZ - 1, "can't allocate fsmtrie: %s",
+		snprintf(err_buf, err_buf_len, "can't allocate fsmtrie: %s",
 				strerror(errno));
 		return (NULL);
 	}
@@ -553,7 +553,7 @@ fsmtrie_insert_token(struct fsmtrie *f, uint32_t *tkey, size_t nkey, const char 
 	for (node_p = f->root, last_parent = NULL, tokidx = 0;
 			tokidx < nkey; tokidx++)
 	{
-		fsmtrie_node_t *node_pp = node_p; 
+		fsmtrie_node_t *node_pp = node_p;
 		int ires;
 		size_t nidx, nnodes;
 

--- a/fsmtrie/fsmtrie.h
+++ b/fsmtrie/fsmtrie.h
@@ -126,7 +126,7 @@ typedef struct fsmtrie_opt * fsmtrie_opt_t;
  *  \returns a valid pointer to a new fsmtrie or NULL and err_buf will contain
  *  the reason
  */
-fsmtrie_t fsmtrie_init(fsmtrie_opt_t opt, char *err_buf);
+fsmtrie_t fsmtrie_init(fsmtrie_opt_t opt, char *err_buf, size_t err_buf_len);
 
 /**
  *  Initialize a new fsmtrie options object. This function MUST be called
@@ -375,7 +375,7 @@ int fsmtrie_search_token(fsmtrie_t fsmtrie, const uint32_t *key,
  * most \p dist characters (this is a bounded edit distance search).
  *
  * Valid for \p fsmtrie_mode_ascii and \p fsmtrie_mode_eascii fsmtries.
- * 
+ *
  * The callback has the following prototype:
  *
  *`static void cb(const char *str, int dist, void *data);`

--- a/tests/test-trie-insert-and-asearch-subsearch.c
+++ b/tests/test-trie-insert-and-asearch-subsearch.c
@@ -79,7 +79,8 @@ START_TEST(test_trie_insert_and_asearch_subsearch)
 	ck_assert_int_eq(fsmtrie_opt_set_mode(opt, fsmtrie_mode_ascii), 1);
 	ck_assert_int_eq(fsmtrie_opt_set_maxlength(opt, 64), 1);
 	ck_assert_int_eq(fsmtrie_opt_set_partialmatch(opt, true), 1);
-	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf), NULL);
+	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf)),
+	    NULL);
 
 	for (n = 0; keys[n]; n++)
 	{

--- a/tests/test-trie-insert-and-search.c
+++ b/tests/test-trie-insert-and-search.c
@@ -33,7 +33,8 @@ START_TEST(test_trie_insert_and_search)
 	ck_assert_int_eq(fsmtrie_opt_set_mode(opt, fsmtrie_mode_ascii), 1);
 	ck_assert_int_eq(fsmtrie_opt_set_maxlength(opt, 64), 1);
 	ck_assert_int_eq(fsmtrie_opt_set_partialmatch(opt, true), 1);
-	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf), NULL);
+	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf)),
+	    NULL);
 
 	for (n = 0; keys[n]; n++)
 	{
@@ -110,7 +111,8 @@ START_TEST(test_trie_insert_and_search_token)
 	ck_assert_ptr_ne(opt = fsmtrie_opt_init(), NULL);
 	ck_assert_int_eq(fsmtrie_opt_set_mode(opt, fsmtrie_mode_token), 1);
 	ck_assert_int_eq(fsmtrie_opt_set_maxlength(opt, 10), 1);
-	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf), NULL);
+	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf)),
+	    NULL);
 
 	for (n = 0; n < 10; n++)
 	{
@@ -159,7 +161,8 @@ START_TEST(test_trie_insert_and_search_ml)
 	ck_assert_int_eq(fsmtrie_opt_set_mode(opt, fsmtrie_mode_ascii), 1);
 	max_len = strlen(keys[0]);
 	ck_assert_int_eq(fsmtrie_opt_set_maxlength(opt, max_len), 1);
-	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf), NULL);
+	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf)),
+	    NULL);
 
 	/* fits */
 	ck_assert_int_eq(fsmtrie_insert(fsmtrie, keys[0], keys[0]), 1);
@@ -197,7 +200,8 @@ START_TEST(test_trie_insert_and_search_utf8)
 	ck_assert_ptr_ne(opt = fsmtrie_opt_init(), NULL);
 	ck_assert_int_eq(fsmtrie_opt_set_mode(opt, fsmtrie_mode_eascii), 1);
 	ck_assert_int_eq(fsmtrie_opt_set_partialmatch(opt, true), 1);
-	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf), NULL);
+	ck_assert_ptr_ne(fsmtrie = fsmtrie_init(opt, err_buf, sizeof (err_buf)),
+	    NULL);
 
 	for (n = 0; keys[n]; n++)
 	{


### PR DESCRIPTION
There are a few use cases of fsmtrie_init() in the AXA source in the following form:

```
        char err_buf[BUFSIZ];
        [...]
        m->ld_trie = fsmtrie_init(fsmtrie_opt, err_buf);
        if (m->ld_trie == NULL)
        {
                snprintf(m->err_buf, sizeof (m->err_buf),
                                "%s(): can't initialize ld fsmtrie: %s\n",
                                __func__, err_buf);
                goto done;
        }
```
The problem here is that m->err_buf is also of BUFSIZ size, so we run into errors like

```
homograph.c:286:41: warning: ‘%s’ directive output may be truncated writing up to 8191 bytes into a region of size 8149 [-Wformat-truncation=]
  286 |     "%s(): can't initialize ld fsmtrie: %s\n",
      |                                         ^~
  287 |     __func__, err_buf);
      |               ~~~~~~~      
```
